### PR TITLE
Expose C interface for SDL_image

### DIFF
--- a/src/image.zig
+++ b/src/image.zig
@@ -1,6 +1,8 @@
 const SDL = @import("lib.zig");
-const c = @import("binding/sdl_image.zig");
 const std = @import("std");
+
+/// Exports the C interface for SDL_image
+pub const c = @import("binding/sdl_image.zig");
 
 pub const InitFlags = packed struct {
     jpg: bool = false, // IMG_INIT_JPG = 1,


### PR DESCRIPTION
The C interface for base SDL is already exposed in lib.zig, this does the same for SDL_image in image.zig