### PR TITLE
update gen_sdl.sh to fix some "zig test"-detected errors

### DIFF
--- a/gen_sdl.sh
+++ b/gen_sdl.sh
@@ -7,7 +7,7 @@ INFILE="/home/felix/projects/SDL/include/SDL.h"
 # this should not be changed
 OUTFILE="src/binding/sdl.zig"
 
-setopt -e
+set -e #setopt -e
 clear
 zig translate-c \
   -target x86_64-linux-gnu \


### PR DESCRIPTION
Running the script against the just-released SDL-2.0.16 resulted in some errors for me, so I added some new substitutions to `gen_sdl.sh`.
(The regenerated bindings are not included, because it seems the previous bindings were generated from Linux, and I didn't want to change that.)
Not sure if these are due to Zig updates, the new SDL version, or me being on Windows, but the new lines shouldn't break anything.

- Added an exception to deleting types ending with `_t` if they span multiple lines (leads to syntax errors otherwise).
- The file contained `NULL` as function arguments in two places, replace those with `null` (it's the first argument in both places, so I didn't try to generalize to anything else yet).
- Some functions referred to `__builtin_bswap{16,32,64}` intrinsics, replace those with the `@byteSwap` builtin.

Points 2 and 3 could arguably be relevant to translate-c, but I didn't take the time to report them upstream (/ look for duplicates).

----

On a different note, the `setopt` command wasn't recognized by my shell (some MSYS2-shell that came with Git for Windows, reports `$BASH_VERSION` as `4.4.19(2)-release`).
Being relatively unversed in POSIX, I asked Google:
- setopt is a `zsh`-builtin. The script is declared `#!/bin/bash` though. The bash equivalent might be `shopt`.
- `setopt -e` should make the script exit on error. I didn't find the equivalent `shopt` option, however `set -e` apparently does the same, so I switched it to that.


I guess I could have made two separate PRs, or a PR and an issue. Just take what you like from this.