### PR TITLE
Fix incorrect cast in gl.setAttribute()

### DIFF
--- a/src/wrapper/gl.zig
+++ b/src/wrapper/gl.zig
@@ -72,7 +72,7 @@ pub fn setAttribute(attrib: Attribute) !void {
     inline for (std.meta.fields(Attribute)) |fld| {
         if (attrib == @field(AttributeName, fld.name)) {
             const res = c.SDL_GL_SetAttribute(
-                @intToEnum(c.SDL_GLattr, @enumToInt(attrib)),
+                @intCast(c.SDL_GLattr, @enumToInt(attrib)),
                 attribValueToInt(@field(attrib, fld.name)),
             );
             if (res != 0) {


### PR DESCRIPTION
One of the changes introduced in commit 32d9ea3 was a change in the type of SDL_GLattr from an enum to a c_uint, but the cast builtin used in gl.setAttribute() was not changed to reflect this.