### PR TITLE
wrapper/sdl.zig: fix pointer mutability in Renderer.copy

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -396,7 +396,7 @@ pub const Renderer = struct {
     }
 
     pub fn copy(ren: Renderer, tex: Texture, dstRect: ?Rectangle, srcRect: ?Rectangle) !void {
-        if (c.SDL_RenderCopy(ren.ptr, tex.ptr, if (srcRect) |r| r.getConstSdlPtr() else null, if (dstRect) |r| r.getSdlPtr() else null) < 0)
+        if (c.SDL_RenderCopy(ren.ptr, tex.ptr, if (srcRect) |r| r.getConstSdlPtr() else null, if (dstRect) |r| r.getConstSdlPtr() else null) < 0)
             return makeError();
     }
 


### PR DESCRIPTION
The `dstrect` argument is a const-pointer input argument, describing the region to render to, and not mutable, see https://wiki.libsdl.org/SDL_RenderCopy .
This was incorrectly changed in 0ccbd2b5 (and I believe the code was silently broken? since the capture was by-value and not mutable either).

On an unrelated note, I was quite surprised that the wrapper changes the argument order of `srcRect` and `dstRect`.
I guess it's trying to go in line with `memcpy`?
A bit annoying when looking at the official reference leads you to writing incorrect code, but I assume it was a conscious decision, whatever the reasoning.