### PR TITLE
wrapper/sdl.zig: nicer KeyboardEvent, add KeyModifierSet and -Bit

### DIFF
--- a/examples/wrapper.zig
+++ b/examples/wrapper.zig
@@ -29,9 +29,9 @@ pub fn main() !void {
                     break :mainLoop;
                 },
                 .key_down => |key| {
-                    switch (key.keysym.scancode) {
-                        SDL.c.SDL_SCANCODE_ESCAPE => break :mainLoop,
-                        else => std.debug.warn("key pressed: {}\n", .{key.keysym.scancode}),
+                    switch (key.scancode) {
+                        .escape => break :mainLoop,
+                        else => std.debug.warn("key pressed: {}\n", .{key.scancode}),
                     }
                 },
 


### PR DESCRIPTION
Unpacks `c.SDL_KeyboardEvent` into a Zig struct with wrapped `Scancode` and `Keycode` enums.

I opted to leave the `KeyModifierSet` packed, the idea being that we don't generate unnecessary bit-masking code if the user chooses to ignore the modifier state.
But then again, maybe the optimizer would inline and discard that code anyway, so I'm open to change it to a `struct` holding `bool` flags instead, which would be in line with `InitFlags` etc.