### PR TITLE
wrapper: fix waitEvent error condition, expand doc comments

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -944,6 +944,8 @@ pub const Event = union(enum) {
     }
 };
 
+/// This function should only be called from
+/// the thread that initialized the video subsystem.
 pub fn pumpEvents() void {
     c.SDL_PumpEvents();
 }
@@ -962,17 +964,22 @@ pub fn pollNativeEvent() ?c.SDL_Event {
     return null;
 }
 
-/// Waits indefinetly until a new event is pumped into the queue
-/// Does not conserve energy
-pub fn waitEvent() ?Event {
+/// Waits indefinitely to pump a new event into the queue.
+/// May not conserve energy on some systems, in some versions/situations.
+/// This function should only be called from
+/// the thread that initialized the video subsystem.
+pub fn waitEvent() !Event {
     var ev: c.SDL_Event = undefined;
     if (c.SDL_WaitEvent(&ev) != 0)
         return Event.from(ev);
-    return null;
+    return makeError();
 }
 
-/// Waits `timeout` milliseconds for the next available event to be pumped
-/// Does not conserve energy
+/// Waits `timeout` milliseconds
+/// to pump the next available event into the queue.
+/// May not conserve energy on some systems, in some versions/situations.
+/// This function should only be called from
+/// the thread that initialized the video subsystem.
 pub fn waitEventTimeout(timeout: usize) ?Event {
     var ev: c.SDL_Event = undefined;
     if (c.SDL_WaitEventTimeout(&ev, timeout) != 0)


### PR DESCRIPTION
As [documentation](https://wiki.libsdl.org/SDL_WaitEvent) states:
> Returns 1 on success or 0 if there was an error while waiting for events; call SDL_GetError() for more information.

Code untested, but this seems more correct to me.

As for `waitEventTimeout`, [the situation is more dubious](https://wiki.libsdl.org/SDL_WaitEventTimeout):
> This also returns 0 if the timeout elapsed without an event arriving.

I asked upstream (https://github.com/libsdl-org/SDL/issues/5052), the proper fix will depend on the reply to that.

I also adapted the doc comments to include the limitation on the caller thread.
I believe the original "Does not conserve energy" remark is due to a busy-loop polling implementation, which should have been addressed for some platforms some of the time in https://github.com/libsdl-org/SDL/pull/4419 .