### PR TITLE
wrapper/sdl.zig: add `fn getModState()`

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -1284,6 +1284,10 @@ pub fn getKeyboardState() KeyboardState {
         .states = slice[0..@intCast(usize, len)],
     };
 }
+pub const getModState = getKeyboardModifierState;
+pub fn getKeyboardModifierState() KeyModifierSet {
+    return KeyModifierSet.fromNative(@intCast(u16, c.SDL_GetModState()));
+}
 
 pub const Keycode = enum(c.SDL_Keycode) {
     unknown = c.SDLK_UNKNOWN,


### PR DESCRIPTION
(with a nicer alias `getKeyboardModifierState`)