### PR TITLE
wrapper/sdl.zig: MouseButtonState fixes

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -838,9 +838,8 @@ pub const MouseButtonState = struct {
     storage: Storage,
 
     fn maskForButton(button_id: MouseButton) Storage {
-        const mask = c.SDL_BUTTON(@enumToInt(button_id));
-        const mask_unsigned = @bitCast(NativeBitField, mask);
-        return @intCast(Storage, mask_unsigned);
+        const mask = @as(NativeBitField, 1) << (@enumToInt(button_id) - 1);
+        return @intCast(Storage, mask);
     }
 
     pub fn getPressed(self: MouseButtonState, button_id: MouseButton) bool {

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -831,9 +831,7 @@ pub const MouseButton = enum(u3) {
 };
 pub const MouseButtonState = struct {
     pub const NativeBitField = u32;
-    // All known values would fit in a u5,
-    // do we want to truncate it to that?
-    pub const Storage = NativeBitField;
+    pub const Storage = u5;
 
     storage: Storage,
 

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -845,7 +845,7 @@ pub const MouseButtonState = struct {
     pub fn getPressed(self: MouseButtonState, button_id: MouseButton) bool {
         return (self.storage & maskForButton(button_id)) != 0;
     }
-    pub fn setPressed(self: MouseButtonState, button_id: MouseButton) void {
+    pub fn setPressed(self: *MouseButtonState, button_id: MouseButton) void {
         self.storage |= maskForButton(button_id);
     }
     pub fn setUnpressed(self: *MouseButtonState, button_id: MouseButton) void {


### PR DESCRIPTION
Fixes `maskForButton`, `setPressed`, and reduces it from translated int size to the number of bits SDL currently defines.