### PR TITLE
Load images using RWop

### DIFF
--- a/src/binding/sdl_image.zig
+++ b/src/binding/sdl_image.zig
@@ -11,5 +11,8 @@ pub extern fn IMG_Quit() void;
 pub extern fn IMG_LoadTexture(renderer: ?*sdl.SDL_Renderer, file: [*c]const u8) ?*sdl.SDL_Texture;
 pub extern fn IMG_Load(file: [*:0]const u8) ?*sdl.SDL_Surface;
 
+pub extern fn IMG_LoadPNG_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadJPG_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+
 pub const IMG_SetError = sdl.SDL_SetError;
 pub const IMG_GetError = sdl.SDL_GetError;

--- a/src/binding/sdl_image.zig
+++ b/src/binding/sdl_image.zig
@@ -10,36 +10,23 @@ pub extern fn IMG_Quit() void;
 
 pub extern fn IMG_LoadTexture(renderer: ?*sdl.SDL_Renderer, file: [*c]const u8) ?*sdl.SDL_Texture;
 pub extern fn IMG_Load(file: [*:0]const u8) ?*sdl.SDL_Surface;
-// https://www.libsdl.org/projects/SDL_image/docs/SDL_image_10.html#SEC10
-// Automagic Loading
-// - [X] IMG_Load	  	Load from a file
-// - [X] IMG_Load_RW	  	Load using a SDL_RWop
-// - [X] IMG_LoadTyped_RW	  	Load more format specifically with a SDL_RWop
-// Specific Loaders
-// - [X] IMG_LoadBMP_RW	  	Load BMP using a SDL_RWop
-// - [ ] IMG_LoadCUR_RW	  	Load CUR using a SDL_RWop
-// - [ ] IMG_LoadGIF_RW	  	Load GIF using a SDL_RWop
-// - [ ] IMG_LoadICO_RW	  	Load ICO using a SDL_RWop
-// - [X] IMG_LoadJPG_RW	  	Load JPG using a SDL_RWop
-// - [ ] IMG_LoadLBM_RW	  	Load LBM using a SDL_RWop
-// - [ ] IMG_LoadPCX_RW	  	Load PCX using a SDL_RWop
-// - [ ] IMG_LoadPNG_RW	  	Load PNG using a SDL_RWop
-// - [ ] IMG_LoadPNM_RW	  	Load PNM using a SDL_RWop
-// - [ ] IMG_LoadTGA_RW	  	Load TGA using a SDL_RWop
-// - [ ] IMG_LoadTIF_RW	  	Load TIF using a SDL_RWop
-// - [ ] IMG_LoadXCF_RW	  	Load XCF using a SDL_RWop
-// - [ ] IMG_LoadXPM_RW	  	Load XPM using a SDL_RWop
-// - [ ] IMG_LoadXV_RW	  	Load XV using a SDL_RWop
-// Array Loaders
-// - [ ] IMG_ReadXPMFromArray	  	Load XPM from compiled XPM data
-pub extern fn IMG_IMG_LoadTyped_RW(rw:*sdl.SDL_RWops, freesrc: c_int, type: [*:0]const u8) ?*sdl.SDL_Surface;
+
+pub extern fn IMG_LoadTyped_RW(rw:*sdl.SDL_RWops, freesrc: c_int, type: [*:0]const u8) ?*sdl.SDL_Surface;
 pub extern fn IMG_Load_RW(rw:*sdl.SDL_RWops, freesrc: c_int) ?*sdl.SDL_Surface; 
 pub extern fn IMG_LoadBMP_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
 pub extern fn IMG_LoadCUR_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
 pub extern fn IMG_LoadGIF_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
 pub extern fn IMG_LoadICO_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
 pub extern fn IMG_LoadJPG_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadLBM_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadPCX_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
 pub extern fn IMG_LoadPNG_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadPNM_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadTGA_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadTIF_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadXCF_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadXPM_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadXV_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
 
 pub const IMG_SetError = sdl.SDL_SetError;
 pub const IMG_GetError = sdl.SDL_GetError;

--- a/src/binding/sdl_image.zig
+++ b/src/binding/sdl_image.zig
@@ -10,9 +10,35 @@ pub extern fn IMG_Quit() void;
 
 pub extern fn IMG_LoadTexture(renderer: ?*sdl.SDL_Renderer, file: [*c]const u8) ?*sdl.SDL_Texture;
 pub extern fn IMG_Load(file: [*:0]const u8) ?*sdl.SDL_Surface;
-
-pub extern fn IMG_LoadPNG_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+// https://www.libsdl.org/projects/SDL_image/docs/SDL_image_10.html#SEC10
+// Automagic Loading
+// - [X] IMG_Load	  	Load from a file
+// - [ ] IMG_Load_RW	  	Load using a SDL_RWop
+// - [ ] IMG_LoadTyped_RW	  	Load more format specifically with a SDL_RWop
+// Specific Loaders
+// - [X] IMG_LoadBMP_RW	  	Load BMP using a SDL_RWop
+// - [ ] IMG_LoadCUR_RW	  	Load CUR using a SDL_RWop
+// - [ ] IMG_LoadGIF_RW	  	Load GIF using a SDL_RWop
+// - [ ] IMG_LoadICO_RW	  	Load ICO using a SDL_RWop
+// - [X] IMG_LoadJPG_RW	  	Load JPG using a SDL_RWop
+// - [ ] IMG_LoadLBM_RW	  	Load LBM using a SDL_RWop
+// - [ ] IMG_LoadPCX_RW	  	Load PCX using a SDL_RWop
+// - [ ] IMG_LoadPNG_RW	  	Load PNG using a SDL_RWop
+// - [ ] IMG_LoadPNM_RW	  	Load PNM using a SDL_RWop
+// - [ ] IMG_LoadTGA_RW	  	Load TGA using a SDL_RWop
+// - [ ] IMG_LoadTIF_RW	  	Load TIF using a SDL_RWop
+// - [ ] IMG_LoadXCF_RW	  	Load XCF using a SDL_RWop
+// - [ ] IMG_LoadXPM_RW	  	Load XPM using a SDL_RWop
+// - [ ] IMG_LoadXV_RW	  	Load XV using a SDL_RWop
+// Array Loaders
+// - [ ] IMG_ReadXPMFromArray	  	Load XPM from compiled XPM data
+pub extern fn IMG_Load_RW(rw:*sdl.SDL_RWops, freesrc: c_int) ?*sdl.SDL_Surface; 
+pub extern fn IMG_LoadBMP_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadCUR_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadGIF_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadICO_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
 pub extern fn IMG_LoadJPG_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
+pub extern fn IMG_LoadPNG_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
 
 pub const IMG_SetError = sdl.SDL_SetError;
 pub const IMG_GetError = sdl.SDL_GetError;

--- a/src/binding/sdl_image.zig
+++ b/src/binding/sdl_image.zig
@@ -13,8 +13,8 @@ pub extern fn IMG_Load(file: [*:0]const u8) ?*sdl.SDL_Surface;
 // https://www.libsdl.org/projects/SDL_image/docs/SDL_image_10.html#SEC10
 // Automagic Loading
 // - [X] IMG_Load	  	Load from a file
-// - [ ] IMG_Load_RW	  	Load using a SDL_RWop
-// - [ ] IMG_LoadTyped_RW	  	Load more format specifically with a SDL_RWop
+// - [X] IMG_Load_RW	  	Load using a SDL_RWop
+// - [X] IMG_LoadTyped_RW	  	Load more format specifically with a SDL_RWop
 // Specific Loaders
 // - [X] IMG_LoadBMP_RW	  	Load BMP using a SDL_RWop
 // - [ ] IMG_LoadCUR_RW	  	Load CUR using a SDL_RWop
@@ -32,6 +32,7 @@ pub extern fn IMG_Load(file: [*:0]const u8) ?*sdl.SDL_Surface;
 // - [ ] IMG_LoadXV_RW	  	Load XV using a SDL_RWop
 // Array Loaders
 // - [ ] IMG_ReadXPMFromArray	  	Load XPM from compiled XPM data
+pub extern fn IMG_IMG_LoadTyped_RW(rw:*sdl.SDL_RWops, freesrc: c_int, type: [*:0]const u8) ?*sdl.SDL_Surface;
 pub extern fn IMG_Load_RW(rw:*sdl.SDL_RWops, freesrc: c_int) ?*sdl.SDL_Surface; 
 pub extern fn IMG_LoadBMP_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;
 pub extern fn IMG_LoadCUR_RW(rw: *sdl.SDL_RWops) ?*sdl.SDL_Surface;

--- a/src/wrapper/image.zig
+++ b/src/wrapper/image.zig
@@ -32,25 +32,6 @@ pub fn loadSurface(file: [:0]const u8) !SDL.Surface {
     };
 }
 
-pub fn loadSurfaceRW(file: [:0]const u8) !SDL.Surface {
-    return SDL.Surface{
-        .ptr = c.IMG_Load_RW(file) orelse return SDL.makeError(),
-    };
-}
-
-//pub fn loadPngSurface(rw: *SDL.c.SDL_RWops) !SDL.Surface {
-//    return SDL.Surface{
-//        .ptr = c.IMG_LoadPNG_RW(rw) orelse return SDL.makeError(),
-//    };
-//}
-//
-//pub fn loadJpgSurface(rw: *SDL.c.SDL_RWops) !SDL.Surface {
-//    return SDL.Surface{
-//        .ptr = c.IMG_LoadJPG_RW(rw) orelse return SDL.makeError(),
-//    };
-//}
-
-
 test "platform independent declarations" {
     std.testing.refAllDecls(@This());
 }

--- a/src/wrapper/image.zig
+++ b/src/wrapper/image.zig
@@ -32,17 +32,23 @@ pub fn loadSurface(file: [:0]const u8) !SDL.Surface {
     };
 }
 
-pub fn loadPngSurface(rw: *SDL.c.SDL_RWops) !SDL.Surface {
+pub fn loadSurfaceRW(file: [:0]const u8) !SDL.Surface {
     return SDL.Surface{
-        .ptr = c.IMG_LoadPNG_RW(rw) orelse return SDL.makeError(),
+        .ptr = c.IMG_Load_RW(file) orelse return SDL.makeError(),
     };
 }
 
-pub fn loadJpgSurface(rw: *SDL.c.SDL_RWops) !SDL.Surface {
-    return SDL.Surface{
-        .ptr = c.IMG_LoadJPG_RW(rw) orelse return SDL.makeError(),
-    };
-}
+//pub fn loadPngSurface(rw: *SDL.c.SDL_RWops) !SDL.Surface {
+//    return SDL.Surface{
+//        .ptr = c.IMG_LoadPNG_RW(rw) orelse return SDL.makeError(),
+//    };
+//}
+//
+//pub fn loadJpgSurface(rw: *SDL.c.SDL_RWops) !SDL.Surface {
+//    return SDL.Surface{
+//        .ptr = c.IMG_LoadJPG_RW(rw) orelse return SDL.makeError(),
+//    };
+//}
 
 
 test "platform independent declarations" {

--- a/src/wrapper/image.zig
+++ b/src/wrapper/image.zig
@@ -32,6 +32,19 @@ pub fn loadSurface(file: [:0]const u8) !SDL.Surface {
     };
 }
 
+pub fn loadPngSurface(rw: *SDL.c.SDL_RWops) !SDL.Surface {
+    return SDL.Surface{
+        .ptr = c.IMG_LoadPNG_RW(rw) orelse return SDL.makeError(),
+    };
+}
+
+pub fn loadJpgSurface(rw: *SDL.c.SDL_RWops) !SDL.Surface {
+    return SDL.Surface{
+        .ptr = c.IMG_LoadJPG_RW(rw) orelse return SDL.makeError(),
+    };
+}
+
+
 test "platform independent declarations" {
     std.testing.refAllDecls(@This());
 }


### PR DESCRIPTION
Hello, 
Thank you for the many zig libraries that you work on, I was experimenting with sdl and needed to load some files program from memory. This wasn't in the native file yet, this adds bindings to load a surface using RWops. Now you can use rwops for sdl image. 
```
const embed = @embedFile("zero.png");
    const rw = SDL.c.SDL_RWFromConstMem(
        @ptrCast(*const anyopaque, &embed[0]),
        @intCast(c_int, embed.len)
    ) orelse return SDL.makeError();
    defer _ = SDL.c.SDL_RWclose(rw);
    // Using the native resolve function that can pick the right load binding
    var surface = SDL.image.c.IMG_Load_RW(rw, 0) orelse return SDL.makeError();
    // Specified format, case insensitive:
    //var surface = SDL.image.c.IMG_LoadTyped_RW(rw, 0, "PNG");
    // or call the function for the type itself:
    //var loadedRW =  SDL.image.c.IMG_LoadPNG_RW(rw) orelse return SDL.makeError();
    defer SDL.c.SDL_FreeSurface(surface);

    var texture = SDL.c.SDL_CreateTextureFromSurface(renderer.ptr, @ptrCast(*SDL.c.SDL_Surface, surface)) orelse return SDL.makeError();
    defer SDL.c.SDL_DestroyTexture(texture);

```
I added "IMG_ReadXPMFromArray" at first was wasn't able to include it in a readable way. In cpp you can use include on the file. unsure what to do in zig it should be c code or campatible atleast.