### PR TITLE
More error handling

### DIFF
--- a/examples/wrapper.zig
+++ b/examples/wrapper.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
         .{ .centered = {} },
         640,
         480,
-        .{ .shown = true },
+        .{ .vis = .shown },
     );
     defer window.destroy();
 

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -224,14 +224,17 @@ pub fn init(flags: InitFlags) !void {
         return makeError();
 }
 
-pub const initSubmodule = init;
+pub fn initSubSystem(flags: InitFlags) !void {
+    if(c.SDL_InitSubSystem(flags.as_u32()) < 0)
+        return makeError();
+}
 
 pub fn wasInit(flags: InitFlags) InitFlags {
     return InitFlags.from_u32(c.SDL_WasInit(flags.as_u32()));
 }
 
-pub fn quitSubsystem(flags: InitFlags) void {
-    c.SDL_QuitSubmodule(flags.as_u32());
+pub fn quitSubSystem(flags: InitFlags) void {
+    c.SDL_QuitSubSystem(flags.as_u32());
 }
 
 pub fn quit() void {

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -310,35 +310,20 @@ pub const WindowPosition = union(enum) {
 };
 
 pub const WindowFlags = struct {
-    /// fullscreen window
-    fullscreen: bool = false, // SDL_WINDOW_FULLSCREEN,
+    /// Window dimension
+    dim: Dimension = .default,
 
-    /// fullscreen window at the current desktop resolution,
-    fullscreen_desktop: bool = false, // SDL_WINDOW_FULLSCREEN_DESKTOP
+    /// Window context
+    context: Context = .default,
 
-    /// window usable with OpenGL context
-    opengl: bool = false, //  SDL_WINDOW_OPENGL,
-
-    /// window usable with Vulkan context
-    vulkan: bool = false, //  SDL_WINDOW_VULKAN,
-
-    /// window is visible,
-    shown: bool = false, //  SDL_WINDOW_SHOWN,
-
-    /// window is not visible
-    hidden: bool = false, //  SDL_WINDOW_HIDDEN,
+    /// Window visibility
+    vis: Visibility = .default,
 
     /// no window decoration
     borderless: bool = false, // SDL_WINDOW_BORDERLESS,
 
     /// window can be resized
     resizable: bool = false, // SDL_WINDOW_RESIZABLE,
-
-    /// window is minimized
-    minimized: bool = false, // SDL_WINDOW_MINIMIZED,
-
-    /// window is maximized
-    maximized: bool = false, // SDL_WINDOW_MAXIMIZED,
 
     ///  window has grabbed input focus
     input_grabbed: bool = false, // SDL_WINDOW_INPUT_GRABBED,
@@ -373,6 +358,31 @@ pub const WindowFlags = struct {
     /// window should be treated as a popup menu (X11 only, >= SDL 2.0.5)
     popup_menu: bool = false, //SDL_WINDOW_POPUP_MENU,
 
+    /// Context window should be usable with
+    pub const Context = enum {
+        opengl, //SDL_WINDOW_OPENGL
+        vulkan, //SDL_WINDOW_VULKAN
+        metal, // SDL_WINDOW_METAL
+        default
+    };
+
+    /// If window should be hidden or shown
+    pub const Visibility = enum {
+        shown, // SDL_WINDOW_SHOWN
+        hidden, // SDL_WINDOW_HIDDEN
+        default
+    };
+
+    /// Dimension with which the window is created with
+    pub const Dimension = enum {
+        fullscreen, // SDL_WINDOW_FULLSCREEN
+        /// Fullscreen window at current resolution
+        fullscreen_desktop, // SDL_WINDOW_FULLSCREEN_DESKTOP
+        maximized, // SDL_WINDOW_MAXIMIZED
+        minimized, // SDL_WINDOW_MINIMIZED
+        default
+    };
+
     // fn fromInteger(val: c_uint) WindowFlags {
     //     // TODO: Implement
     //     @panic("niy");
@@ -380,16 +390,26 @@ pub const WindowFlags = struct {
 
     fn toInteger(wf: WindowFlags) c_int {
         var val: c_int = 0;
-        if (wf.fullscreen) val |= c.SDL_WINDOW_FULLSCREEN;
-        if (wf.fullscreen_desktop) val |= c.SDL_WINDOW_FULLSCREEN_DESKTOP;
-        if (wf.opengl) val |= c.SDL_WINDOW_OPENGL;
-        if (wf.vulkan) val |= c.SDL_WINDOW_VULKAN;
-        if (wf.shown) val |= c.SDL_WINDOW_SHOWN;
-        if (wf.hidden) val |= c.SDL_WINDOW_HIDDEN;
+        switch(wf.dim) {
+            .fullscreen => val |= c.SDL_WINDOW_FULLSCREEN,
+            .fullscreen_desktop => val |= c.SDL_WINDOW_FULLSCREEN_DESKTOP,
+            .maximized => val |= c.SDL_WINDOW_MAXIMIZED,
+            .minimized => val |= c.SDL_WINDOW_MINIMIZED,
+            .default => {}
+        }
+        switch(wf.context) {
+            .vulkan => val |= c.SDL_WINDOW_VULKAN,
+            .opengl => val |= c.SDL_WINDOW_OPENGL,
+            .metal => val |= c.SDL_WINDOW_METAL,
+            .default => {}
+        }
+        switch(wf.vis) {
+            .shown => val |= c.SDL_WINDOW_SHOWN,
+            .hidden => val |= c.SDL_WINDOW_HIDDEN,
+            .default => {}
+        }
         if (wf.borderless) val |= c.SDL_WINDOW_BORDERLESS;
         if (wf.resizable) val |= c.SDL_WINDOW_RESIZABLE;
-        if (wf.minimized) val |= c.SDL_WINDOW_MINIMIZED;
-        if (wf.maximized) val |= c.SDL_WINDOW_MAXIMIZED;
         if (wf.input_grabbed) val |= c.SDL_WINDOW_INPUT_GRABBED;
         if (wf.input_focus) val |= c.SDL_WINDOW_INPUT_FOCUS;
         if (wf.mouse_focus) val |= c.SDL_WINDOW_MOUSE_FOCUS;

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -220,11 +220,15 @@ pub const InitFlags = struct {
 };
 
 pub fn init(flags: InitFlags) !void {
+    const empty_flags = InitFlags{};
+    if(flags == empty_flags) return error.EmptyFlags;
     if (c.SDL_Init(flags.as_u32()) < 0)
         return makeError();
 }
 
 pub fn initSubSystem(flags: InitFlags) !void {
+    const empty_flags = InitFlags{};
+    if(flags == empty_flags) return error.EmptyFlags;
     if(c.SDL_InitSubSystem(flags.as_u32()) < 0)
         return makeError();
 }

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -227,11 +227,8 @@ pub fn init(flags: InitFlags) !void {
 }
 
 pub fn initSubSystem(flags: InitFlags) !void {
-<<<<<<< HEAD
     const empty_flags = InitFlags{};
     if(flags == empty_flags) return error.EmptyInitFlags;
-=======
->>>>>>> 0eaf5ef9db9c83a276253ae2a452f819d95b4ee4
     if(c.SDL_InitSubSystem(flags.as_u32()) < 0)
         return makeError();
 }

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -221,14 +221,14 @@ pub const InitFlags = struct {
 
 pub fn init(flags: InitFlags) !void {
     const empty_flags = InitFlags{};
-    if(flags == empty_flags) return error.EmptyFlags;
+    if(flags == empty_flags) return error.EmptyInitFlags;
     if (c.SDL_Init(flags.as_u32()) < 0)
         return makeError();
 }
 
 pub fn initSubSystem(flags: InitFlags) !void {
     const empty_flags = InitFlags{};
-    if(flags == empty_flags) return error.EmptyFlags;
+    if(flags == empty_flags) return error.EmptyInitFlags;
     if(c.SDL_InitSubSystem(flags.as_u32()) < 0)
         return makeError();
 }

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -220,15 +220,13 @@ pub const InitFlags = struct {
 };
 
 pub fn init(flags: InitFlags) !void {
-    const empty_flags = InitFlags{};
-    if(flags == empty_flags) return error.EmptyInitFlags;
+    if(flags.as_u32() == 0) return error.EmptyInitFlags;
     if (c.SDL_Init(flags.as_u32()) < 0)
         return makeError();
 }
 
 pub fn initSubSystem(flags: InitFlags) !void {
-    const empty_flags = InitFlags{};
-    if(flags == empty_flags) return error.EmptyInitFlags;
+    if(flags.as_u32() == 0) return error.EmptyInitFlags;
     if(c.SDL_InitSubSystem(flags.as_u32()) < 0)
         return makeError();
 }

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -224,8 +224,14 @@ pub fn init(flags: InitFlags) !void {
         return makeError();
 }
 
+pub const initSubmodule = init;
+
 pub fn wasInit(flags: InitFlags) InitFlags {
     return InitFlags.from_u32(c.SDL_WasInit(flags.as_u32()));
+}
+
+pub fn quitSubsystem(flags: InitFlags) void {
+    c.SDL_QuitSubmodule(flags.as_u32());
 }
 
 pub fn quit() void {


### PR DESCRIPTION
In SDL if you pass to a window both Vulcan and OpenGL as context, it throws a runtime error. But in zig we can do better by creating enums and giving compile time errors. Not only that, but when we call SDL_Init it makes no sense to initialize no subsystem so we can throw an error.