### PR TITLE
wrapper: fix Rectangle.getConstSdlPtr self parameter type

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -29,8 +29,8 @@ pub const Rectangle = extern struct {
     fn getSdlPtr(r: *Rectangle) *c.SDL_Rect {
         return @ptrCast(*c.SDL_Rect, r);
     }
-    fn getConstSdlPtr(r: Rectangle) *const c.SDL_Rect {
-        return @ptrCast(*const c.SDL_Rect, &r);
+    fn getConstSdlPtr(r: *const Rectangle) *const c.SDL_Rect {
+        return @ptrCast(*const c.SDL_Rect, r);
     }
 };
 


### PR DESCRIPTION
Previously it technically returned a dangling reference to what could have been a local copy.