### PR TITLE
wrapper: fix createRgbSurfaceWithFormat arguments

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -494,8 +494,8 @@ pub fn loadBmp(filename: [:0]const u8) !Surface {
     return makeError();
 }
 
-pub fn createRgbSurfaceWithFormat(width: u31, height: u31, bit_depth: u31, format: PixelFormatEnum) !Surface {
-    return Surface{ .ptr = c.SDL_CreateRGBSurfaceWithFormat(0, width, height, bit_depth, @enumToInt(format)) orelse return error.SdlError };
+pub fn createRgbSurfaceWithFormat(width: u31, height: u31, format: PixelFormatEnum) !Surface {
+    return Surface{ .ptr = c.SDL_CreateRGBSurfaceWithFormat(undefined, width, height, undefined, @enumToInt(format)) orelse return error.SdlError };
 }
 
 pub fn blitScaled(src: Surface, src_rectangle: ?*Rectangle, dest: Surface, dest_rectangle: ?*Rectangle) !void {


### PR DESCRIPTION
As noted in SDL commit [507ce36](https://github.com/libsdl-org/SDL/commit/507ce36d807dd409963f59fdf9f51fcc8dd00dcb) ,
the parameters flags and depth are both completely unused.
From what I could find this has been the case since the function's
introduction in commit [d2676c2](https://github.com/libsdl-org/SDL/commit/d2676c2985359dd7e9240b14e3e1f13079f781d2) .

Therefore they should not be exposed to callers,
and given `undefined` values.