### PR TITLE
Added wrapper functions for basic intersects.

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -49,7 +49,7 @@ pub fn hasIntersection(a: *Rectangle, b: *Rectangle) bool {
     return false;
 }
 
-pub fn intersectRect(a: *Rectangle, b: *Rectangle, result: Rectangle) bool {
+pub fn intersectRect(a: *Rectangle, b: *Rectangle, result: *Rectangle) bool {
     if (c.SDL_IntersectRect(a.getSdlPtr(), b.getSdlPtr(), result.getSdlPtr()) == 1) {
         return true;
     }

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -42,6 +42,27 @@ pub const Rectangle = extern struct {
     }
 };
 
+pub fn hasIntersection(a: *Rectangle, b: *Rectangle) bool {
+    if (c.SDL_HasIntersection(a.getSdlPtr(), b.getSdlPtr()) == 1) {
+        return true;
+    }
+    return false;
+}
+
+pub fn intersectRect(a: *Rectangle, b: *Rectangle, result: Rectangle) bool {
+    if (c.SDL_IntersectRect(a.getSdlPtr(), b.getSdlPtr(), result.getSdlPtr()) == 1) {
+        return true;
+    }
+    return false;
+}
+
+pub fn intersectRectAndLine(rect: Rectangle, x1: *c_int, y1: *c_int, x2: *c_int, y2: *c_int) bool {
+    if (c.SDL_IntersectRectAndLine(rect.getSdlPtr(), x1, y1, x2, y2) == 1) {
+        return true;
+    }
+    return false;
+}
+
 pub const RectangleF = extern struct {
     x: f32,
     y: f32,


### PR DESCRIPTION
Added a few basic wrappers for intersection. Used `bool` instead of `SDL_BOOL`, I believe this is a legacy thing from the sdl library. Also couldn't find SDL_BOOL in the bindings.

Also noticed `c_int` is used in the binding structs `Rectangle` etc so I kept the parameters `c_int` instead of making `i32` and casting those in the bindings.