### PR TITLE
Respond to Build.zig Breaking Changes

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -146,9 +146,12 @@ pub fn link(sdk: *Sdk, exe: *LibExeObjStep, linkage: std.build.LibExeObjStep.Lin
         // we compile a stub .so file we will link against an SDL2.so even if that file
         // doesn't exist on our system
 
-        const build_linux_sdl_stub = b.addSharedLibrary("SDL2", null, .unversioned);
+        const build_linux_sdl_stub = b.addSharedLibrary(.{
+            .name = "SDL2",
+            .target = exe.target,
+            .optimize = exe.optimize,
+        });
         build_linux_sdl_stub.addAssemblyFileSource(sdk.prepare_sources.getStubFile());
-        build_linux_sdl_stub.setTarget(exe.target);
 
         // We need to link against libc
         exe.linkLibC();

--- a/build.zig
+++ b/build.zig
@@ -7,21 +7,17 @@ const Builder = std.build.Builder;
 pub fn build(b: *Builder) !void {
     const sdk = Sdk.init(b);
 
-    const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
     const sdl_linkage = b.option(std.build.LibExeObjStep.Linkage, "link", "Defines how to link SDL2 when building with mingw32") orelse .dynamic;
 
     const skip_tests = b.option(bool, "skip-test", "When set, skips the test suite to be run. This is required for cross-builds") orelse false;
 
     if (!skip_tests) {
-        const lib_test = b.addTest("src/wrapper/sdl.zig");
-        lib_test.setTarget(.{
-            // copy over the abi so we compile the test with -msvc or -gnu for windows
-            .abi = if (target.isWindows())
-                target.abi
-            else
-                null,
+        const lib_test = b.addTest(.{
+            .root_source_file = .{ .path = "src/wrapper/sdl.zig" },
+            .target = .{ .abi = if (target.isWindows()) target.abi else null },
         });
         lib_test.addPackage(sdk.getNativePackage("sdl-native"));
         lib_test.linkSystemLibrary("sdl2_image");
@@ -47,16 +43,22 @@ pub fn build(b: *Builder) !void {
         test_lib_step.dependOn(&lib_test.step);
     }
 
-    const demo_wrapper = b.addExecutable("demo-wrapper", "examples/wrapper.zig");
-    demo_wrapper.setBuildMode(mode);
-    demo_wrapper.setTarget(target);
+    const demo_wrapper = b.addExecutable(.{
+        .name = "demo-wrapper",
+        .root_source_file = .{ .path = "examples/wrapper.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
     sdk.link(demo_wrapper, sdl_linkage);
     demo_wrapper.addPackage(sdk.getWrapperPackage("sdl2"));
     demo_wrapper.install();
 
-    const demo_wrapper_image = b.addExecutable("demo-wrapper-image", "examples/wrapper-image.zig");
-    demo_wrapper_image.setBuildMode(mode);
-    demo_wrapper_image.setTarget(target);
+    const demo_wrapper_image = b.addExecutable(.{
+        .name = "demo-wrapper-image",
+        .root_source_file = .{ .path = "examples/wrapper-image.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
     sdk.link(demo_wrapper_image, sdl_linkage);
     demo_wrapper_image.addPackage(sdk.getWrapperPackage("sdl2"));
     demo_wrapper_image.linkSystemLibrary("sdl2_image");
@@ -66,9 +68,12 @@ pub fn build(b: *Builder) !void {
     demo_wrapper_image.linkSystemLibrary("webp");
     demo_wrapper_image.install();
 
-    const demo_native = b.addExecutable("demo-native", "examples/native.zig");
-    demo_native.setBuildMode(mode);
-    demo_native.setTarget(target);
+    const demo_native = b.addExecutable(.{
+        .name = "demo-native",
+        .root_source_file = .{ .path = "examples/native.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
     sdk.link(demo_native, sdl_linkage);
     demo_native.addPackage(sdk.getNativePackage("sdl2"));
     demo_native.install();


### PR DESCRIPTION
`Sdk.zig` makes use of `addSharedLibrary` which had it's API changed.

`build.zig` uses a  lot of fns that were either removed or had their API changed. 