### PR TITLE
Update for std.build.Cache change

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -504,7 +504,7 @@ const CacheBuilder = struct {
                 self.build.allocator,
                 "{s}/{s}/o/{}",
                 .{
-                    self.build.cache_root,
+                    self.build.cache_root.path.?,
                     subdir,
                     std.fmt.fmtSliceHexLower(&hash),
                 },
@@ -514,7 +514,7 @@ const CacheBuilder = struct {
                 self.build.allocator,
                 "{s}/o/{}",
                 .{
-                    self.build.cache_root,
+                    self.build.cache_root.path.?,
                     std.fmt.fmtSliceHexLower(&hash),
                 },
             );


### PR DESCRIPTION
The Zig master branch has recently changed the type of the `cache_root` field of `std.Build` to be a `std.Build.Cache.Directory`. I'm not familiar with what the caching strategy employed by `Sdk.zig` is, so I don't know if there is a better way to leverage the new `std.Build.Cache` API in `Sdk.zig` - this is just the minimum change I made that got things successfully compiling for me.