### PR TITLE
Change the wrapper update texture function signature

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -916,7 +916,7 @@ pub const Texture = struct {
         };
     }
 
-    pub fn update(texture: Texture, pixels: []const u8, pitch: usize, rectangle: ?Rectangle) !void {
+    pub fn update(texture: Texture, pixels: []const anyopaque, pitch: usize, rectangle: ?Rectangle) !void {
         if (c.SDL_UpdateTexture(
             texture.ptr,
             if (rectangle) |rect| rect.getConstSdlPtr() else null,


### PR DESCRIPTION
SDL takes a pointer to void for the texture update function, the wrapper currently takes a const array of u8's instead of a const array of anyopaque. 