### PR TITLE
Improve sdl.json instructions for Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -311,7 +311,9 @@ pub fn link(sdk: *Sdk, exe: *LibExeObjStep, linkage: LibExeObjStep.Linkage) void
                     ) catch @panic("io error");
                     writer.writeAll(
                         \\
-                        \\You can obtain a SDL2 sdk for windows from https://www.libsdl.org/download-2.0.php
+                        \\You can obtain a SDL2 sdk for windows from https://github.com/libsdl-org/SDL/releases/tag/release-2.26.5
+                        \\
+                        \\You can download the "SDL2-devel-2.26.5-mingw.zip", the relevant include/libs/bin folders are in "x86_64-w64-mingw32"
                         \\
                     ) catch @panic("io error");
                 },
@@ -329,7 +331,8 @@ pub fn link(sdk: *Sdk, exe: *LibExeObjStep, linkage: LibExeObjStep.Linkage) void
                     ) catch @panic("io error");
                     writer.writeAll(
                         \\
-                        \\You can obtain a SDL2 sdk for windows from https://www.libsdl.org/download-2.0.php
+                        \\You can obtain a SDL2 sdk for windows from https://github.com/libsdl-org/SDL/releases/tag/release-2.26.5
+                        \\You'll likely want to download the "SDL2-devel-2.26.5-mingw.zip", the relevant include/libs/bin folders are in "x86_64-w64-mingw32"
                         \\
                     ) catch @panic("io error");
                 },

--- a/build.zig
+++ b/build.zig
@@ -311,9 +311,9 @@ pub fn link(sdk: *Sdk, exe: *LibExeObjStep, linkage: LibExeObjStep.Linkage) void
                     ) catch @panic("io error");
                     writer.writeAll(
                         \\
-                        \\You can obtain a SDL2 sdk for windows from https://github.com/libsdl-org/SDL/releases/tag/release-2.26.5
+                        \\You can obtain a SDL2 sdk for windows from https://github.com/libsdl-org/SDL/releases/latest
                         \\
-                        \\You can download the "SDL2-devel-2.26.5-mingw.zip", the relevant include/libs/bin folders are in "x86_64-w64-mingw32"
+                        \\You can download the "SDL2-devel-X.XX.X-mingw.zip", the relevant include/libs/bin folders are in "x86_64-w64-mingw32"
                         \\
                     ) catch @panic("io error");
                 },
@@ -331,8 +331,8 @@ pub fn link(sdk: *Sdk, exe: *LibExeObjStep, linkage: LibExeObjStep.Linkage) void
                     ) catch @panic("io error");
                     writer.writeAll(
                         \\
-                        \\You can obtain a SDL2 sdk for windows from https://github.com/libsdl-org/SDL/releases/tag/release-2.26.5
-                        \\You'll likely want to download the "SDL2-devel-2.26.5-mingw.zip", the relevant include/libs/bin folders are in "x86_64-w64-mingw32"
+                        \\You can obtain a SDL2 sdk for windows from https://github.com/libsdl-org/SDL/releases/latest
+                        \\You'll likely want to download the "SDL2-devel-X.XX.X-mingw.zip", the relevant include/libs/bin folders are in "x86_64-w64-mingw32"
                         \\
                     ) catch @panic("io error");
                 },


### PR DESCRIPTION
**Why do this?**

- https://www.libsdl.org/download-2.0.php just redirects you to Github. Not sure if this is intentional
- SDL2-devel-2.26.5-mingw.zip provides the necessary files to compile so adding that to the instructions felt clearer to me.
- SDL2-devel-2.26.5-VC.zip did not have a bin folder, so I assume this is incompatible with how this builds, but I haven't tested it. The DLL is in the lib folder.