### PR TITLE
fix deprecated functions and update example to use .target instead of setTarget

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ const Sdk = @import("Sdk.zig"); // Import the Sdk at build time
 pub fn build(b: *std.Build.Builder) !void {
     // Determine compilation target
     const target = b.standardTargetOptions(.{});
-  
+
     // Create a new instance of the SDL2 Sdk
     const sdk = Sdk.init(b, null);
 
@@ -23,16 +23,15 @@ pub fn build(b: *std.Build.Builder) !void {
     const demo_basic = b.addExecutable(.{
         .name = "demo-basic",
         .root_source_file = .{ .path = "my-game.zig" },
+        .target = target,
     });
-    
-    demo_basic.setTarget(target);   // must be done before calling sdk.link
     sdk.link(demo_basic, .dynamic); // link SDL2 as a shared library
 
     // Add "sdl2" package that exposes the SDL2 api (like SDL_Init or SDL_CreateWindow)
-    demo_basic.addModule("sdl2", sdk.getNativeModule()); 
+    demo_basic.addModule("sdl2", sdk.getNativeModule());
 
     // Install the executable into the prefix when invoking "zig build"
-    demo_basic.install();
+    std.Build.installArtifact(b, demo_basic);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build.Builder) !void {
     demo_basic.addModule("sdl2", sdk.getNativeModule());
 
     // Install the executable into the prefix when invoking "zig build"
-    std.Build.installArtifact(b, demo_basic);
+    b.installArtifact(demo_basic);
 }
 ```
 

--- a/build.zig
+++ b/build.zig
@@ -55,7 +55,7 @@ pub fn build(b: *Builder) !void {
     });
     sdk.link(demo_wrapper, sdl_linkage);
     demo_wrapper.addModule("sdl2", sdk.getWrapperModule());
-    std.Build.installArtifact(b, demo_wrapper);
+    b.installArtifact(demo_wrapper);
 
     const demo_wrapper_image = b.addExecutable(.{
         .name = "demo-wrapper-image",
@@ -70,7 +70,7 @@ pub fn build(b: *Builder) !void {
     demo_wrapper_image.linkSystemLibrary("libpng");
     demo_wrapper_image.linkSystemLibrary("tiff");
     demo_wrapper_image.linkSystemLibrary("webp");
-    std.Build.installArtifact(b, demo_wrapper_image);
+    b.installArtifact(demo_wrapper_image);
 
     const demo_native = b.addExecutable(.{
         .name = "demo-native",
@@ -80,7 +80,7 @@ pub fn build(b: *Builder) !void {
     });
     sdk.link(demo_native, sdl_linkage);
     demo_native.addModule("sdl2", sdk.getNativeModule());
-    std.Build.installArtifact(b, demo_native);
+    b.installArtifact(demo_native);
 
     const run_demo_wrappr = b.addRunArtifact(demo_wrapper);
 

--- a/build.zig
+++ b/build.zig
@@ -55,7 +55,7 @@ pub fn build(b: *Builder) !void {
     });
     sdk.link(demo_wrapper, sdl_linkage);
     demo_wrapper.addModule("sdl2", sdk.getWrapperModule());
-    b.installArtifact(demo_wrapper);
+    std.Build.installArtifact(b, demo_wrapper);
 
     const demo_wrapper_image = b.addExecutable(.{
         .name = "demo-wrapper-image",
@@ -70,7 +70,7 @@ pub fn build(b: *Builder) !void {
     demo_wrapper_image.linkSystemLibrary("libpng");
     demo_wrapper_image.linkSystemLibrary("tiff");
     demo_wrapper_image.linkSystemLibrary("webp");
-    b.installArtifact(demo_wrapper_image);
+    std.Build.installArtifact(b, demo_wrapper_image);
 
     const demo_native = b.addExecutable(.{
         .name = "demo-native",
@@ -80,7 +80,7 @@ pub fn build(b: *Builder) !void {
     });
     sdk.link(demo_native, sdl_linkage);
     demo_native.addModule("sdl2", sdk.getNativeModule());
-    b.installArtifact(demo_native);
+    std.Build.installArtifact(b, demo_native);
 
     const run_demo_wrappr = b.addRunArtifact(demo_wrapper);
 


### PR DESCRIPTION
**Zig Version**

0.11.0-dev.3299+34865d693

**Changes**

- Change `b.install(demo)` calls to `std.Build.installArtifact(b, demo);`
- Update example from using `demo_basic.setTarget(target);` to setting `.target = target` in `b.addExecutable`