### PR TITLE
wrapper/sdl: default to 0 for x/y fields of Rectangle

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -30,8 +30,8 @@ pub fn makeError() error{SdlError} {
 }
 
 pub const Rectangle = extern struct {
-    x: c_int,
-    y: c_int,
+    x: c_int = 0,
+    y: c_int = 0,
     width: c_int,
     height: c_int,
 


### PR DESCRIPTION
This makes multiple function calls look cleaner.
```zig
// compare this (with defaults)
try renderer.setViewport(.{
    .width = 1920,
    .height = 1080,
});

// to this (without defaults)
try renderer.setViewport(.{
    .x = 0,
    .y = 0,
    .width = 1920,
    .height = 1080,
});
```
I see how this could be rejected (less explicit), but I think it's obvious than a `Rectangle` has `.x` and `.y` even without errors, especially if the user read the sources and/or has an LSP setup.