### PR TITLE
fix: only use sdl2 sub when cross-compiling

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -254,7 +254,7 @@ pub fn link(sdk: *Sdk, exe: *Compile, linkage: Compile.Linkage) void {
 
     const b = sdk.build;
     const target = exe.root_module.resolved_target.?;
-    const is_native = target.query.isNative();
+    const is_native = target.query.isNativeOs();
 
     // This is required on all platforms
     exe.linkLibC();


### PR DESCRIPTION
isNative() will return false if CPU isn't native e.g. Dcpu=baseline, even when building a linux executable on a linux distro like ubuntu