### PR TITLE
fix: paths to SDL files in .build_config should be .cwd_relative

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -353,15 +353,15 @@ pub fn link(sdk: *Sdk, exe: *Compile, linkage: std.builtin.LinkMode) void {
                 sdk_paths.include,
                 "SDL2",
             }) catch @panic("out of memory");
-            exe.addIncludePath(.{ .path = include_path });
+            exe.addIncludePath(.{ .cwd_relative = include_path });
         } else {
-            exe.addIncludePath(.{ .path = sdk_paths.include });
+            exe.addIncludePath(.{ .cwd_relative = sdk_paths.include });
         }
 
         // link the right libraries
         if (target.result.abi == .msvc) {
             // and links those as normal libraries
-            exe.addLibraryPath(.{ .path = sdk_paths.libs });
+            exe.addLibraryPath(.{ .cwd_relative = sdk_paths.libs });
             exe.linkSystemLibrary2("SDL2", .{ .use_pkg_config = .no });
         } else {
             const file_name = switch (linkage) {
@@ -374,7 +374,7 @@ pub fn link(sdk: *Sdk, exe: *Compile, linkage: std.builtin.LinkMode) void {
                 file_name,
             }) catch @panic("out of memory");
 
-            exe.addObjectFile(.{ .path = lib_path });
+            exe.addObjectFile(.{ .cwd_relative = lib_path });
 
             if (linkage == .static) {
                 // link all system libraries required for SDL2:

--- a/build.zig
+++ b/build.zig
@@ -336,7 +336,7 @@ pub fn link(sdk: *Sdk, exe: *Compile, linkage: std.builtin.LinkMode) void {
                 },
             }
 
-            std.os.exit(1);
+            std.process.exit(1);
         };
 
         // linking on windows is sadly not as trivial as on linux:


### PR DESCRIPTION
Currently in a project where I try to link SDL to a `*Compile` provided by zig's new package manager. I get bogus errors like: 
```
error: unable to check cache: stat file 'D:\a\turbo\turbo\zig-cache\C:\Users\runneradmin\AppData\Local\zig\p\1220dbf1d809d07d1910b9853f162458ed1ebc66be81b21ccfc40a2552bc1019f9c2\.build_config\SDL2\lib\libSDL2.dll.a' failed: FileNotFound
```

As far as I'm aware, the file paths listed in `sdl.json` (from `.build_config\`) could very well be absolute and even if they're not (in my case), they don't seem to be that accessible to executables that exist in zig's cache as opposed to the build root. 

By using `.cwd_relative` instead of `.path` when working with `sdk_paths` SDL.zig can link to artifacts from the package manager. 


